### PR TITLE
Fix error in <=IE9

### DIFF
--- a/dist/angular-file-saver.bundle.js
+++ b/dist/angular-file-saver.bundle.js
@@ -563,7 +563,10 @@ module.exports = function Blob($window) {
 'use strict';
 
 module.exports = function SaveAs() {
-  return require('FileSaver.js').saveAs;
+  var sa = require('FileSaver.js').saveAs;
+  //check for undefined for IE and modern browsers
+  sa = sa !== "undefined" && sa !== undefined ? sa : { error: "Unsupported" };
+  return sa;
 };
 
 },{"FileSaver.js":2}],7:[function(require,module,exports){


### PR DESCRIPTION
Returns an "error" object in unsupported browsers to satisfy Angular factory requirements that we at least return an object.

*Need to check for undefined without brackets in IE9