### PR TITLE
Fix repo paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "homepage": "https://github.com/alferov/angular-file-saver",
   "dependencies": {
-    "Blob.js": "https://github.com/alferov/Blob.js",
-    "FileSaver.js": "https://github.com/alferov/FileSaver.js"
+    "Blob.js": "git+https://github.com/alferov/Blob.js",
+    "FileSaver.js": "git+https://github.com/alferov/FileSaver.js"
   },
   "devDependencies": {
     "angular": "^1.4.5",


### PR DESCRIPTION
This changes the repo URL's of the dependencies to follow the [package.json documentation](https://docs.npmjs.com/files/package.json#git-urls-as-dependencies).

Without this change, npm 1.4.x fails on `ERR not a package` during installation. After this change, node 0.10.x users can install the package and ignore the engine version warning at their own risk. :wink: 