### PR TITLE
Export angular module name

### DIFF
--- a/src/angular-file-saver-bundle.module.js
+++ b/src/angular-file-saver-bundle.module.js
@@ -1,5 +1,5 @@
 'use strict';
-
+module.exports = 'ngFileSaver';
 /*
 *
 * A AngularJS module that implements the HTML5 W3C saveAs() in browsers that


### PR DESCRIPTION
Enables angular to reference the ngFileSaver-module. Fixes #11. 